### PR TITLE
package.json field adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,12 @@
   "name": "web-worker",
   "version": "0.1.0",
   "description": "Consistent Web Workers in browser and Node.",
-  "main": "cjs/node.js",
-  "browser": "cjs/browser.js",
+  "main": "./cjs/node.js",
+  "browser": "./cjs/browser.js",
   "exports": {
-    ".": {
-      "module": "node.js",
-      "node": "cjs/node.js",
-      "require": "cjs/node.js"
-    }
+    "browser": "./cjs/browser.js",
+    "node": "./cjs/node.js",
+    "default": "./cjs/node.js"
   },
   "files": [
     "cjs",


### PR DESCRIPTION
Note that `"exports"` RHS targets must start with `"./"` and will be ignored otherwise (ultimately leading to a not found error if none of them work).

The `"."` entry can also be left out now as a single entry point sugar.

As of the 13.7 release (coming out tomorrow with some luck), `"node"` will be supported in exports. I've kept the `"default"` field in for older versions of Node.js 13 without conditional exports unflagged.

Then I'm trying to make the `"browser"` condition happen... you don't have to go with it though :) Ideally I'd also like to see `"development"` and `"production"` conditions in tools.

If you want to experiment with separated module entry points happy to discuss the setup for that too... should be relatively straightforward.

