### PR TITLE
Fix typings not included in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "cjs",
     "browser.js",
-    "node.js"
+    "node.js",
+    "index.d.ts"
   ],
   "scripts": {
     "prepare": "babel node.js browser.js -d cjs",


### PR DESCRIPTION
Can be verified by running `npm pack` locally.