### PR TITLE
feat: Support self.close inside node workers

### DIFF
--- a/node.js
+++ b/node.js
@@ -159,6 +159,10 @@ function workerThread() {
 		postMessage(data, transferList) {
 			threads.parentPort.postMessage(data, transferList);
 		}
+		// Emulates https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/close
+		close() {
+			process.exit();
+		}
 	}
 	let proto = Object.getPrototypeOf(global);
 	delete proto.constructor;

--- a/test/fixtures/close.mjs
+++ b/test/fixtures/close.mjs
@@ -1,0 +1,1 @@
+self.close();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,9 +70,8 @@ test.serial('close', async t => {
 	const worker = new Worker('./test/fixtures/close.mjs', { type: 'module' });
 	let closed = false;
 	// Not emitted in the browser, just for testing
-	worker.addEventListener('close', e => {
-		closed = true;
+	await new Promise((resolve, reject) => {
+	  worker.addEventListener('close', resolve);
+	  setTimeout(reject, 500);
 	});
-	await sleep(500);
-	t.is(closed, true, 'should have closed itself');
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -68,10 +68,10 @@ test.serial('postMessage', async t => {
 
 test.serial('close', async t => {
 	const worker = new Worker('./test/fixtures/close.mjs', { type: 'module' });
-	let closed = false;
 	// Not emitted in the browser, just for testing
-	await new Promise((resolve, reject) => {
-	  worker.addEventListener('close', resolve);
-	  setTimeout(reject, 500);
+	const closed = await new Promise((resolve, reject) => {
+		worker.addEventListener('close', () => resolve(true));
+		setTimeout(reject, 500);
 	});
+	t.is(closed, true, 'should have closed itself');
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,3 +65,14 @@ test.serial('postMessage', async t => {
 	t.deepEqual(second.data[2], msg);
 	t.not(second.data[2], msg);
 });
+
+test.serial('close', async t => {
+	const worker = new Worker('./test/fixtures/close.mjs', { type: 'module' });
+	let closed = false;
+	// Not emitted in the browser, just for testing
+	worker.addEventListener('close', e => {
+		closed = true;
+	});
+	await sleep(500);
+	t.is(closed, true, 'should have closed itself');
+});


### PR DESCRIPTION
This adds the `self.close()` function that is available in a Worker's global scope, as per https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/close