### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,1 @@
-type ConstructorOf<C> = { new (...args: any[]): C }
-
-declare const _default: ConstructorOf<Worker>
-export default _default
+export = Worker;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     "browser": "./cjs/browser.js",
     "node": "./cjs/node.js",
-    "default": "./cjs/node.js"
+    "default": "./cjs/node.js",
+    "types": "./index.d.ts"
   },
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
- Add types entry exports[0]. I'm sad TypeScript doesn't seem to be
  using the plain old types field but it isn't.
- Replace index.d.ts' `export default` with `export =`[1]. From what I
  can tell, `module.exports` is always used for all entrypoints so this
  is the correct definition.
- Use the Worker var declaration from lib.dom.d.ts. I think this is fine
  since the old definition already used the Worker interface from the
  same file. This typing is more accurate, easier to read,d less likely
  to become outdated, and less code.

Bug: #20 #22

[0]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing
[1]: https://github.com/microsoft/TypeScript/issues/7185#issuecomment-421632656