### PR TITLE
Implement Blob URLs for Node (experiment)

### DIFF
--- a/node.js
+++ b/node.js
@@ -17,7 +17,7 @@
 import URL from 'url';
 import VM from 'vm';
 import threads from 'worker_threads';
-import {resolveObjectURL} from 'node:buffer'
+import { resolveObjectURL } from 'node:buffer';
 
 const isDataUrl = s => /^data:/.test(s);
 const isBlobUrl = s => /^blob:/.test(s);
@@ -220,7 +220,7 @@ async function parseDataUrl(url, blobUrl) {
 		return {
 			type: blobUrl.type,
 			data: await blobUrl.text()
-		}
+		};
 	}
 
 	let [m, type, encoding, data] = url.match(/^data: *([^;,]*)(?: *; *([^,]*))? *,(.*)$/) || [];


### PR DESCRIPTION
This attempts to add support for Blob URLs for Node.

Should fix #30. But I'm not sure if any other details need to be looked into.

Fixes the "TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file" bug that you see when you try to use a Blob.

Tiny little test case:

```js
const Worker = require('web-worker')
const {Blob} = require('node:buffer')

const workerSrc = `
self.onmessage = function(e) {
  self.postMessage('Doing expensive calculation.')
  const t1 = Number(new Date())
  while (true) {
    const t2 = Number(new Date())
    if (t2 > t1 + 1000) {
      break
    }
  }
  postMessage('Done.')
}
`

async function main() {
  const blob = new Blob([workerSrc], {type: 'text/javascript'})
  const blobUrl = URL.createObjectURL(blob)
  const worker = new Worker(blobUrl)
  worker.onmessage = function(e) {
    console.log('msg:', e.data)
    if (e.data === 'Done.') {
      process.exit(0)
    }
  }
  worker.postMessage('start')
}

main()
```