### PR TITLE
add `WorkerGlobalScope` to `global`

### DIFF
--- a/node.js
+++ b/node.js
@@ -172,6 +172,7 @@ function workerThread() {
 		proto[fn] = proto[fn].bind(global);
 	});
 	global.name = name;
+	global.WorkerGlobalScope = WorkerGlobalScope;
 
 	const isDataUrl = /^data:/.test(mod);
 	if (type === 'module') {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "prepare": "babel node.js browser.js -d cjs",
+    "prepare": "npx babel node.js browser.js -d cjs",
     "test": "eslint '*.js' test && node --experimental-modules ./node_modules/.bin/ava"
   },
   "babel": {


### PR DESCRIPTION
The specification says that the constructor should be available in the global scope.

In particular, this is a valid way to check if one is running in a web worker:
```js
if(!(globalThis.WorkerGlobalScope instanceof Function)){
```

https://html.spec.whatwg.org/multipage/workers.html#the-global-scope