### PR TITLE
fix: allow for nesting workers

### DIFF
--- a/node.js
+++ b/node.js
@@ -133,6 +133,7 @@ function mainThread() {
 
 function workerThread() {
 	let { mod, name, type } = threads.workerData;
+	if (!mod) return mainThread();
 
 	// turn global into a mock WorkerGlobalScope
 	const self = global.self = global;


### PR DESCRIPTION
This fixes an issue where it's not possible to use this library inside of a NodeJS worker thread, since the check below is not accounting for where the thread originated from. When using this library within a worker thread, the `workerThread()` code is executed, rather than the `mainThread()` code which creates the worker polyfill.

https://github.com/developit/web-worker/blob/29fef9775702c91887d3d8733e595edf1a188f31/node.js#L73

This change executes `workerThread()` only if the `mod` property is present from the `workerData`, indicating that it's being executed from a thread created within this library. If `mod` isn't present, this means that the code is executing within the context of some other worker thread that wasn't created from this library, and it needs to treat the current thread as the main thread by executing `mainThread()`.

One enhancement might be to randomize the `mod` property name. This change assumes that a parent thread won't send a `mod` property in the `workerData`...
