### PR TITLE
Add Bun support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./cjs/node.js",
   "browser": "./cjs/browser.js",
   "exports": {
+    "bun": "./cjs/browser.js",
     "browser": "./cjs/browser.js",
     "node": "./cjs/node.js",
     "default": "./cjs/node.js"


### PR DESCRIPTION
This adds a `"bun"` package.json `"exports"` condition which loads the browser build in Bun.

Bun implements the Web API  [`Worker`](https://bun.sh/docs/api/workers) natively, and Bun's `node:worker_threads` implementation internally wraps the Web API `Worker`.  

`web-worker` currently loads the polyfills for Node in Bun (since we must recognize the `"node"` package.json `"exports"` condition for compatibility). 

This has actually been pretty helpful for catching bugs in our `node:worker_threads` implementation, but it'd be better for our users to use the native implementation instead of wrapping the native implementation in another wrapper (`node:worker_threads`) in another wrapper (`web-worker`)