### PR TITLE
FIX ReferenceError: Worker is not defined in shared worker

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export default Worker;
+export default typeof Worker !== 'undefined' ? Worker : undefined;


### PR DESCRIPTION
Currently when this package is used somewhere in between a [Shared worker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker), simply the import/require will fail because it does not have the Worker API set on the globals.
`Uncaught ReferenceError: Worker is not defined`

This PR adds a check for `undefined` and only exports the Worker API when it really exists.