### PR TITLE
Fix: Cannot set property currentTarget of #<Event> which has only a getter

### DIFF
--- a/node.js
+++ b/node.js
@@ -28,6 +28,9 @@ class EventTarget {
 		});
 	}
 	dispatchEvent(event) {
+		Object.defineProperty(event, 'target', { writable: false, value: this });
+		Object.defineProperty(event, 'currentTarget', { writable: false, value: this });
+
 		if (this['on'+event.type]) {
 			try {
 				this['on'+event.type](event);
@@ -107,7 +110,7 @@ function mainThread() {
 				value: worker
 			});
 			worker.on('message', data => {
-				const event = new Event('message', this);
+				const event = new Event('message');
 				event.data = data;
 				this.dispatchEvent(event);
 			});
@@ -116,7 +119,7 @@ function mainThread() {
 				this.dispatchEvent(error);
 			});
 			worker.on('exit', () => {
-				this.dispatchEvent(new Event('close', this));
+				this.dispatchEvent(new Event('close'));
 			});
 		}
 		postMessage(data, transferList) {
@@ -145,7 +148,7 @@ function workerThread() {
 		buffered.forEach(event => { self.dispatchEvent(event); });
 	}
 	threads.parentPort.on('message', data => {
-		const event = new Event('message', this);
+		const event = new Event('message');
 		event.data = data;
 		if (q == null) self.dispatchEvent(event);
 		else q.push(event);

--- a/node.js
+++ b/node.js
@@ -28,7 +28,6 @@ class EventTarget {
 		});
 	}
 	dispatchEvent(event) {
-		event.target = event.currentTarget = this;
 		if (this['on'+event.type]) {
 			try {
 				this['on'+event.type](event);
@@ -108,7 +107,7 @@ function mainThread() {
 				value: worker
 			});
 			worker.on('message', data => {
-				const event = new Event('message');
+				const event = new Event('message', this);
 				event.data = data;
 				this.dispatchEvent(event);
 			});
@@ -117,7 +116,7 @@ function mainThread() {
 				this.dispatchEvent(error);
 			});
 			worker.on('exit', () => {
-				this.dispatchEvent(new Event('close'));
+				this.dispatchEvent(new Event('close', this));
 			});
 		}
 		postMessage(data, transferList) {
@@ -146,7 +145,7 @@ function workerThread() {
 		buffered.forEach(event => { self.dispatchEvent(event); });
 	}
 	threads.parentPort.on('message', data => {
-		const event = new Event('message');
+		const event = new Event('message', this);
 		event.data = data;
 		if (q == null) self.dispatchEvent(event);
 		else q.push(event);


### PR DESCRIPTION
Fixes #49 

- Remove affectation to Event.target and Event.currentTarget after initialisation