### PR TITLE
fix: allow importing inside a NodeJS worker with no workerData

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -23,6 +23,9 @@ import threads from 'worker_threads';
 const WORKER = Symbol.for('worker');
 const EVENTS = Symbol.for('events');
 
+// sadly we can't use a symbol here, since it can't be cloned across the thread boundary. so we use a unique string instead.
+const IS_WORKER_ATTR = '__web_worker_is_worker_5ecb39d8-bb28-4239-85f5-4c508c499d39__';
+
 class EventTarget {
 	constructor() {
 		Object.defineProperty(this, EVENTS, {
@@ -104,7 +107,7 @@ function mainThread() {
 			}
 			const worker = new threads.Worker(
 				fileURLToPath(import.meta.url),
-				{ workerData: { mod, name, type } }
+				{ workerData: { mod, name, type, [IS_WORKER_ATTR]: true } }
 			);
 			Object.defineProperty(this, WORKER, {
 				value: worker
@@ -138,8 +141,11 @@ function workerThread() {
 	if (typeof global.WorkerGlobalScope === 'function') {
 		return;
 	}
-	let { mod, name, type } = threads.workerData;
-	if (!mod) return mainThread();
+	if (typeof threads.workerData !== 'object' || !threads.workerData[IS_WORKER_ATTR]) {
+		return mainThread();
+	}
+
+	let { mod, name, type } = threads.workerData ?? {};
 
 	// turn global into a mock WorkerGlobalScope
 	const self = global.self = global;


### PR DESCRIPTION
This PR fixes #57

I added a `?? {}` to the `threads.workerData` destructuring to ensure we have a valid value to destructure. 

In addition to that I added a new attribute with a unique name (includes a UUID, so it's basically impossible to set this by accident)  to the `workerData`.
This ensures we can reliably verify that we are running in a worker thread, which was created by `web-worker`. All other threads will use the `mainThread` code path (and not the `workerThread` code path). 
Something similar was already suggested by [eshaz](https://github.com/eshaz) in #40: 
> [...]
> One enhancement might be to randomize the `mod` property name. This change assumes that a parent thread won't send a `mod` property in the `workerData`...
